### PR TITLE
flake: rename pkgconfig to pkg-config

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
       (system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
-          nativeBuildInputs = with pkgs; [ pkgconfig zfs.dev ];
+          nativeBuildInputs = with pkgs; [ pkg-config zfs.dev ];
         in
         rec {
           devShell =


### PR DESCRIPTION
This was broken after NixOS/nixpkgs#192681