### PR TITLE
Use gitignore.nix to present a reproducible source tree

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -15,12 +15,30 @@
         "type": "github"
       }
     },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1637453606,
-        "narHash": "sha256-Gy6cwUswft9xqsjWxFYEnx/63/qzaFUwatcbV5GF/GQ=",
-        "path": "/nix/store/ql3zf52wdclvqj2rg1kjksnzr2k1qqkr-source",
-        "rev": "8afc4e543663ca0a6a4f496262cd05233737e732",
+        "narHash": "sha256-D8IA+oeofz7LVfdtONBCYUArH4tQQMV+NNLOGhA/BqY=",
+        "path": "/nix/store/ic36bx2hhnaqsbirz0vb8a3988i1pfvh-source",
         "type": "path"
       },
       "original": {
@@ -31,6 +49,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "gitignore": "gitignore",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,14 +3,19 @@
 
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
+    gitignore = {
+      url = "github:hercules-ci/gitignore.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils, ... }:
+  outputs = { self, nixpkgs, flake-utils, gitignore, ... }:
     flake-utils.lib.eachDefaultSystem
       (system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
           nativeBuildInputs = with pkgs; [ pkgconfig zfs.dev ];
+          inherit (gitignore.lib) gitignoreSource;
         in
         rec {
           devShell =
@@ -22,7 +27,7 @@
             pname = "zpool-exporter-textfile";
             version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
             inherit nativeBuildInputs;
-            src = ./.;
+            src = gitignoreSource ./.;
             cargoLock.lockFile = ./Cargo.lock;
 
             buildInputs = nativeBuildInputs;


### PR DESCRIPTION
...instead of just putting everything in the source tree into the store.

This only helps with development a bit (fewer target/ dirs littering the source tree), and it's just a bit more hygienic.