### PR TITLE
Update nix build process

### DIFF
--- a/.github/workflows/nix_update.yml
+++ b/.github/workflows/nix_update.yml
@@ -1,0 +1,29 @@
+name: "nix-update"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "32 19 * * 0"
+
+jobs:
+  flake_update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v3.6.0
+      - uses: cachix/install-nix-action@v22
+      - run: nix flake update
+      - run: nix flake check .
+      - run: nix build --no-link .#
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          commit-message: "Update flake.lock"
+          assignees: antifuchs
+          delete-branch: true
+          branch: flake-update
+          base: main
+          title: "Update flake.lock"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /target
 **/*.rs.bk
 /.direnv/
-/flake.lock

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,148 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1692817259,
+        "narHash": "sha256-eDyI/ieNv4cC/s5dQB1+mQTo+69ZmTwdlNj3syARWWQ=",
+        "path": "/nix/store/gwhakibglw5sflq2hk5y1q7idqif5zjp-source",
+        "rev": "beebb047d4875de98ce95126263764cacbb88e7d",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1681358109,
+        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1693102271,
+        "narHash": "sha256-JuxJYl7zZ9FUOA/3Az5OPYWQfH9Y8SvtqqFnPKB6zUw=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "1aac4029cfbc529f8b39c96d29fe1d09338f9110",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -3,38 +3,50 @@
 
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
     gitignore = {
       url = "github:hercules-ci/gitignore.nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, gitignore, ... }:
+  outputs =
+    { self
+    , nixpkgs
+    , flake-utils
+    , rust-overlay
+    , gitignore
+    , ...
+    }:
     flake-utils.lib.eachDefaultSystem
       (system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-          nativeBuildInputs = with pkgs; [ pkg-config zfs.dev ];
-          inherit (gitignore.lib) gitignoreSource;
-        in
-        rec {
-          devShell =
-            pkgs.mkShell {
-              inherit nativeBuildInputs;
-            };
-
-          packages.zpool-exporter-textfile = pkgs.rustPlatform.buildRustPackage rec {
-            pname = "zpool-exporter-textfile";
-            version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
+      let
+        pkgs = (import nixpkgs { inherit system; overlays = [ (import rust-overlay) ]; });
+        nativeBuildInputs = with pkgs; [ pkg-config zfs.dev ];
+        rustPlatform = pkgs.makeRustPlatform {
+          rustc = pkgs.rust-bin.stable.latest.minimal;
+          cargo = pkgs.rust-bin.stable.latest.minimal;
+        };
+        inherit (gitignore.lib) gitignoreSource;
+      in
+      rec {
+        devShell =
+          pkgs.mkShell {
             inherit nativeBuildInputs;
-            src = gitignoreSource ./.;
-            cargoLock.lockFile = ./Cargo.lock;
-
-            buildInputs = nativeBuildInputs;
           };
 
-          defaultPackage = packages.zpool-exporter-textfile;
-        }) // {
+        packages.zpool-exporter-textfile = rustPlatform.buildRustPackage rec {
+          pname = "zpool-exporter-textfile";
+          version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
+          inherit nativeBuildInputs;
+          src = gitignoreSource ./.;
+          cargoLock.lockFile = ./Cargo.lock;
+
+          buildInputs = nativeBuildInputs;
+        };
+
+        defaultPackage = packages.zpool-exporter-textfile;
+      }) // {
       nixosModules.zpool-exporter-textfile = import ./nixos { flake = self; };
     };
 }


### PR DESCRIPTION
* Do not gitignore the flake.lock file after all, it does seem to cause more trouble than it's worth.

* Use rust-overlay to build with the latest stable version of rust (at the time of `flake.lock` updating)