### PR TITLE
Use generated token to file PR

### DIFF
--- a/.github/workflows/nix_update.yml
+++ b/.github/workflows/nix_update.yml
@@ -17,10 +17,20 @@ jobs:
       - run: nix flake check .
       - run: nix build --no-link .#
 
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ vars.PR_FIXUP_APP_ID }}
+          installation_id: 40623348
+          permissions: >-
+            {"contents": "write", "pull_requests": "write"}
+          private_key: ${{ secrets.PR_FIXUP_APP_PRIVATE_KEY }}
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
+          token: ${{steps.generate_token.outputs.token}}
           commit-message: "Update flake.lock"
           assignees: antifuchs
           delete-branch: true


### PR DESCRIPTION
The built-in GITHUB_TOKEN can not file pull requests that trigger actions, and since we have required statuses set by actions, the PRs filed with that token can never be merged.

Instead, let's use the method suggested [here](https://github.com/orgs/community/discussions/24525#discussioncomment-3244415), by synthesizing a github token out of a github app (which we already have!), and then use that to create the PR.

We could also commit to main directly, but for now I think a weekly PR would be fine.