### PR TITLE
Don't configure the node exporter with our status directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,15 @@ You can use this in a flake like so (I hope!):
         modules = [
           ./configuration.nix
           zpool-exporter.nixosModules.zpool-exporter-textfile
-          {config, ...}: { zpool-exporter-textfile.enable = true; }
+          {config, ...}: {
+            zpool-exporter-textfile = {
+              enable = true;
+              textfileDir = "node_exporter_textfiles";
+            };
+            services.prometheus.exporters.node.extraFlags = [
+              "--collector.textfile.directory=/etc/node_exporter_textfiles/"
+            ];
+          }
         ];
       };
     };

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -35,6 +35,11 @@ in {
         description = "Package containing the zpool-exporter-textfile that we should use to collect statuses.";
         default = flake.packages.${pkgs.stdenv.targetPlatform.system}.zpool-exporter-textfile;
       };
+
+      textfileDir = mkOption {
+        description = "Directory under /etc in which the prometheus node_exporter's textfiles are collected. The node_exporter must be set up to collect the text files in thir directory, via the option `services.prometheus.exporters.node.extraFlags = [" /etc/${config.zpool-exporter-textfile.textfileDir} "]`";
+        type = with types; str;
+      };
     };
   };
 
@@ -79,8 +84,9 @@ in {
             Persistent = true;
           };
         };
-
-        services.prometheus.exporters.node.extraFlags = ["--collector.textfile.directory=/var/lib/zpool-exporter-textfile/"];
+        environment.etc."${config.zpool-exporter-textfile.textfileDir}/zpool-exporter-textfile.prom" = {
+          source = "/var/lib/zpool-exporter-textfile/zpool_statuses.prom";
+        };
       }
     ]);
 }

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -37,7 +37,7 @@ in {
       };
 
       textfileDir = mkOption {
-        description = "Directory under /etc in which the prometheus node_exporter's textfiles are collected. The node_exporter must be set up to collect the text files in thir directory, via the option `services.prometheus.exporters.node.extraFlags = [" /etc/${config.zpool-exporter-textfile.textfileDir} "]`";
+        description = "Directory under /etc in which the prometheus node_exporter's textfiles are collected. The node_exporter must be set up to collect the text files in thir directory, via the option `services.prometheus.exporters.node.extraFlags = [\"--collector.textfile.directory=/etc/\${config.zpool-exporter-textfile.textfileDir}\"]`";
         type = with types; str;
       };
     };


### PR DESCRIPTION
Instead, symlink the textfile into a directory of the user's choice, which they then configure node_exporter to pick up.

This is an incompatible change, but anyone upgrading the version of this exporter should notice, as now the textfileDir option is required.